### PR TITLE
Dev1

### DIFF
--- a/simulation-system/libs/csle-cli/src/csle_cli/cli.py
+++ b/simulation-system/libs/csle-cli/src/csle_cli/cli.py
@@ -10,8 +10,8 @@ from csle_common.dao.simulation_config.simulation_env_config import SimulationEn
 from csle_common.util.cluster_util import ClusterUtil
 from csle_common.util.general_util import GeneralUtil
 from csle_cluster.cluster_manager.cluster_controller import ClusterController
-from csle_cluster.cluster_manager.cluster_manager_pb2 import DockerContainerDTO, ContainerImageDTO
 from typing import TYPE_CHECKING
+
 if TYPE_CHECKING:
     from csle_common.dao.emulation_config.emulation_env_state import EmulationEnvState
     from csle_common.dao.emulation_config.emulation_env_config import EmulationEnvConfig
@@ -643,7 +643,7 @@ def stop_shell_complete(ctx, param, incomplete) -> List[str]:
         emulations=MetastoreFacade.list_emulations())
     emulations: List[str] = running_emulations
     running_containers = ContainerController.list_all_running_containers()
-    containers: List[Tuple[str, str ,str]] = running_containers
+    containers: List[Tuple[str, str, str]] = running_containers
     container_names: List[str] = list(map(lambda x: x[0], containers))
     return ["prometheus", "node_exporter", "cadvisor", "pgadmin", "grafana", "flask",
             "statsmanager", "all", "emulation_executions"] + emulations + container_names
@@ -1039,7 +1039,7 @@ def start_shell_complete(ctx, param, incomplete) -> List[str]:
         emulations=MetastoreFacade.list_emulations())
     emulations = stopped_emulations
     stopped_containers = ContainerController.list_all_stopped_containers()
-    containers: List[Tuple[str, str ,str]] = stopped_containers
+    containers: List[Tuple[str, str, str]] = stopped_containers
     container_names: List[str] = list(map(lambda x: x[0], containers))
     images: List[Tuple[str, str, str, str, str]] = ContainerController.list_all_images()
     image_names: List[str] = list(map(lambda x: x[0], images))
@@ -1313,7 +1313,7 @@ def rm_shell_complete(ctx, param, incomplete) -> List[str]:
     emulations = list(map(lambda x: x.name, MetastoreFacade.list_emulations()))
     running_containers = ContainerController.list_all_running_containers()
     stopped_containers = ContainerController.list_all_stopped_containers()
-    containers: List[Tuple[str, str ,str]] = running_containers + stopped_containers
+    containers: List[Tuple[str, str, str]] = running_containers + stopped_containers
     container_names: List[str] = list(map(lambda x: x[0], containers))
     images: List[Tuple[str, str, str, str, str]] = ContainerController.list_all_images()
     image_names: List[str] = list(map(lambda x: x[0], images))

--- a/simulation-system/libs/csle-rest-api/src/csle_rest_api/resources/pgadmin/routes.py
+++ b/simulation-system/libs/csle-rest-api/src/csle_rest_api/resources/pgadmin/routes.py
@@ -1,14 +1,12 @@
 """
 Routes and sub-resources for the /pgadmin resource
 """
-import json
 from typing import Tuple
-
+import json
+from flask import Blueprint, Response, jsonify, request
 import csle_common.constants.constants as constants
 from csle_cluster.cluster_manager.cluster_controller import ClusterController
 from csle_common.metastore.metastore_facade import MetastoreFacade
-from flask import Blueprint, Response, jsonify, request
-
 import csle_rest_api.constants.constants as api_constants
 import csle_rest_api.util.rest_api_util as rest_api_util
 

--- a/simulation-system/libs/csle-rest-api/src/csle_rest_api/resources/prometheus/routes.py
+++ b/simulation-system/libs/csle-rest-api/src/csle_rest_api/resources/prometheus/routes.py
@@ -1,14 +1,12 @@
 """
 Routes and sub-resources for the /prometheus resource
 """
-import json
 from typing import Tuple
-
+import json
+from flask import Blueprint, Response, jsonify, request
 import csle_common.constants.constants as constants
 from csle_cluster.cluster_manager.cluster_controller import ClusterController
 from csle_common.metastore.metastore_facade import MetastoreFacade
-from flask import Blueprint, Response, jsonify, request
-
 import csle_rest_api.constants.constants as api_constants
 import csle_rest_api.util.rest_api_util as rest_api_util
 

--- a/simulation-system/libs/csle-rest-api/src/csle_rest_api/util/rest_api_util.py
+++ b/simulation-system/libs/csle-rest-api/src/csle_rest_api/util/rest_api_util.py
@@ -1,12 +1,8 @@
-
-
 from typing import Tuple, Union
-
+from flask import Response, jsonify
 import csle_common.constants.constants as constants
 from csle_common.dao.management.management_user import ManagementUser
 from csle_common.metastore.metastore_facade import MetastoreFacade
-from flask import Response, jsonify
-
 import csle_rest_api.constants.constants as api_constants
 
 
@@ -40,7 +36,7 @@ def check_if_user_is_authorized(request, requires_admin: bool = False) -> Union[
         return None
 
 
-def check_if_user_edit_is_authorized(request, user: ManagementUser) -> Union[ManagementUser,
+def check_if_user_edit_is_authorized(request, user: ManagementUser) -> Union[None, ManagementUser,
                                                                              Tuple[Response, int]]:
     """
     Check if a user is authorized to edit another user
@@ -52,10 +48,9 @@ def check_if_user_edit_is_authorized(request, user: ManagementUser) -> Union[Man
     # Extract token and check if user is authorized
     token = request.args.get(api_constants.MGMT_WEBAPP.TOKEN_QUERY_PARAM)
     token_obj = MetastoreFacade.get_session_token_metadata(token=token)
+    request_user = None
     if token_obj is not None:
         request_user = MetastoreFacade.get_management_user_by_username(username=token_obj.username)
-    else:
-        request_user = MetastoreFacade.get_management_user_by_username(username=None)
     if token_obj is None or token_obj.expired(valid_length_hours=api_constants.SESSION_TOKENS.EXPIRE_TIME_HOURS) \
             or request_user is None or (not request_user.admin and request_user.username != user.username):
         if token_obj is not None:

--- a/simulation-system/libs/csle-rest-api/tests/test_resources_pgadmin.py
+++ b/simulation-system/libs/csle-rest-api/tests/test_resources_pgadmin.py
@@ -1,16 +1,14 @@
 import json
-
-import csle_common.constants.constants as constants
 import pytest
 import pytest_mock
+import csle_common.constants.constants as constants
 from csle_cluster.cluster_manager.cluster_manager_pb2 import NodeStatusDTO
 from csle_common.dao.emulation_config.config import Config
-
 import csle_rest_api.constants.constants as api_constants
 from csle_rest_api.rest_api import create_app
 
 
-class TestResourcespgAdminSuite():
+class TestResourcespgAdminSuite:
     """
     Test suite for /pgadmin resource
     """

--- a/simulation-system/libs/csle-rest-api/tests/test_resources_prometheus.py
+++ b/simulation-system/libs/csle-rest-api/tests/test_resources_prometheus.py
@@ -1,11 +1,9 @@
 import json
-
-import csle_common.constants.constants as constants
 import pytest
 import pytest_mock
+import csle_common.constants.constants as constants
 from csle_cluster.cluster_manager.cluster_manager_pb2 import NodeStatusDTO
 from csle_common.dao.emulation_config.config import Config
-
 import csle_rest_api.constants.constants as api_constants
 from csle_rest_api.rest_api import create_app
 

--- a/simulation-system/libs/csle-rest-api/tests/test_rest_api_util.py
+++ b/simulation-system/libs/csle-rest-api/tests/test_rest_api_util.py
@@ -1,22 +1,51 @@
 import json
-
-import csle_common.constants.constants as constants
 import numpy as np
 import pytest
 import pytest_mock
+from flask import Flask
+import csle_common.constants.constants as constants
 from csle_common.dao.management.management_user import ManagementUser
 from csle_common.dao.management.session_token import SessionToken
-from flask import Flask
-
 import csle_rest_api.constants.constants as api_constants
 import csle_rest_api.util.rest_api_util as rest_api_util
 from csle_rest_api.rest_api import create_app
 
 
-class TestUtilSuite:
+class TestRestAPIUtilSuite:
     """
     Test suite for /experiments url
     """
+
+    class SyntReq:
+        """
+        Mock class for synt reg
+        """
+        def __init__(self, args) -> None:
+            """
+            Initializes the object
+
+            :param args: the arguments for syntreg
+            """
+            self.args = args
+
+    class Args:
+        """
+        Mock class for syntehtic arguments to a request
+        """
+        def __init__(self) -> None:
+            """
+            Initializes the object
+            """
+            pass
+
+        def get(self, token: str) -> None:
+            """
+            Mocks the get method of the arguments
+
+            :param token: the token for authentication
+            :return: None
+            """
+            return None
 
     @pytest.fixture
     def flask_app(self):
@@ -28,7 +57,7 @@ class TestUtilSuite:
         return create_app(static_folder="../../../../../management-system/csle-mgmt-webapp/build")
 
     @pytest.fixture
-    def session_token(self, mocker):
+    def session_token(self, mocker: pytest_mock.MockFixture):
         """
         Pytest fixture for mocking the get_session_token_metadata method
 
@@ -41,7 +70,7 @@ class TestUtilSuite:
         return get_session_token_metadata_mocker
     
     @pytest.fixture
-    def session_token_exp(self, mocker):
+    def session_token_exp(self, mocker: pytest_mock.MockFixture):
         """
         Pytest fixture for mocking the get_session_token_metadata method
 
@@ -56,7 +85,7 @@ class TestUtilSuite:
         return get_session_token_metadata_mocker
 
     @pytest.fixture
-    def management_user(self, mocker):
+    def management_user(self, mocker: pytest_mock.MockFixture):
         """
         Pytest fixture for mocking the get_management_user_by_username method
 
@@ -64,14 +93,14 @@ class TestUtilSuite:
         :return: the mocked function
         """
         def get_management_user_by_username(username: str) -> ManagementUser:
-            mng_user = TestUtilSuite.get_synthetic_mng_user()
+            mng_user = TestRestAPIUtilSuite.get_synthetic_mng_user()
             return mng_user
 
         get_management_user_by_username_mocker = mocker.MagicMock(side_effect=get_management_user_by_username)
         return get_management_user_by_username_mocker
 
     @pytest.fixture
-    def management_user_none(self, mocker):
+    def management_user_none(self, mocker: pytest_mock.MockFixture):
         """
         Pytest fixture for mocking the get_management_user_by_username method
 
@@ -85,7 +114,7 @@ class TestUtilSuite:
         return get_management_user_by_username_mocker
 
     @pytest.fixture
-    def remove(self, mocker):
+    def remove(self, mocker: pytest_mock.MockFixture):
         """
         Pytest fixture for mocking the reomve_session_token method
 
@@ -98,30 +127,31 @@ class TestUtilSuite:
         return remove_session_token_mocker
 
     @staticmethod
-    def get_args():
-        class Args():
-            def __init__(self) -> None:
-                pass
+    def get_args() -> Args:
+        """
+        Returns a mock request argument
 
-            def get(self, token: str):
-                return None
-        return Args()
+        :return: the mocked request argument
+        """
+        return TestRestAPIUtilSuite.Args()
 
     @staticmethod
-    def get_synthetic_request(args):
+    def get_synthetic_request(args) -> SyntReq:
         """
         Static help method for returning a synthetic/mocked request, customized to work for testing without the use
         of blueprint or flask app
+
+        :param args: the arguments for the mock request
+        :return: the syntethic request
         """
-        class SyntReq():
-            def __init__(self, args):
-                self.args = args
-        return SyntReq(args)
+        return TestRestAPIUtilSuite.SyntReq(args)
 
     @staticmethod
-    def get_synthetic_mng_user():
+    def get_synthetic_mng_user() -> ManagementUser:
         """
-        static help method for returning a synthetic/mocked management user
+        Static help method for returning a synthetic/mocked management user
+
+        :return: the mocked management user
         """
         mng_user = ManagementUser(username="JDoe", password="JDoe", email="jdoe@csle.com",
                                   first_name="John", last_name="Doe", organization="CSLE",
@@ -144,21 +174,21 @@ class TestUtilSuite:
                      side_effect=session_token)
         mocker.patch("csle_common.metastore.metastore_facade.MetastoreFacade.get_management_user_by_username",
                      side_effect=management_user)
-        mocker.patch("csle_common.metastore.metastore_facade.MetastoreFacade.remove_session_token",
-                     side_effect=remove)
+        mocker.patch("csle_common.metastore.metastore_facade.MetastoreFacade.remove_session_token", side_effect=remove)
         app = Flask(__name__)
-        mng_user = TestUtilSuite.get_synthetic_mng_user()
-        args = TestUtilSuite.get_args()
-        req = TestUtilSuite.get_synthetic_request(args)
+        mng_user = TestRestAPIUtilSuite.get_synthetic_mng_user()
+        args = TestRestAPIUtilSuite.get_args()
+        req = TestRestAPIUtilSuite.get_synthetic_request(args)
         with app.app_context():
             response = rest_api_util.check_if_user_is_authorized(request=req)
-            response1 = rest_api_util.check_if_user_edit_is_authorized(request=req,
-                                                                       user=mng_user)
+            response1 = rest_api_util.check_if_user_edit_is_authorized(request=req, user=mng_user)
+        assert response is not None
         response_data = response[0].data.decode("utf-8")
         response_data_dict = json.loads(response_data)
         response_status_code = response[1]
         assert response_data_dict == {}
         assert response_status_code == constants.HTTPS.UNAUTHORIZED_STATUS_CODE
+        assert response1 is not None
         response_data1 = response1[0].data.decode("utf-8")
         response_data_dict1 = json.loads(response_data1)
         response_status_code1 = response1[1]
@@ -167,8 +197,8 @@ class TestUtilSuite:
         mocker.patch("csle_common.metastore.metastore_facade.MetastoreFacade.get_management_user_by_username",
                      side_effect=management_user_none)
         with app.app_context():
-            response1 = rest_api_util.check_if_user_edit_is_authorized(request=req,
-                                                                       user=mng_user)
+            response1 = rest_api_util.check_if_user_edit_is_authorized(request=req, user=mng_user)
+        assert response1 is not None
         response_data1 = response1[0].data.decode("utf-8")
         response_data_dict1 = json.loads(response_data1)
         response_status_code1 = response1[1]
@@ -178,8 +208,7 @@ class TestUtilSuite:
                      side_effect=management_user)
         with app.app_context():
             response = rest_api_util.check_if_user_is_authorized(request=req)
-            response1 = rest_api_util.check_if_user_edit_is_authorized(request=req,
-                                                                       user=mng_user)
+        assert response is not None
         response_data = response[0].data.decode("utf-8")
         response_data_dict = json.loads(response_data)
         response_status_code = response[1]
@@ -189,10 +218,11 @@ class TestUtilSuite:
                      side_effect=session_token_exp)
         with app.app_context():
             response = rest_api_util.check_if_user_is_authorized(request=req)
-            response1 = rest_api_util.check_if_user_edit_is_authorized(request=req,
-                                                                       user=mng_user)
+            response1 = rest_api_util.check_if_user_edit_is_authorized(request=req, user=mng_user)
         assert response is None
-        ex_mng_user = TestUtilSuite.get_synthetic_mng_user()
+        assert response1 is not None
+        assert isinstance(response1, ManagementUser)
+        ex_mng_user = TestRestAPIUtilSuite.get_synthetic_mng_user()
         assert response1.username == ex_mng_user.username
         assert response1.password == ex_mng_user.password
         assert response1.admin == ex_mng_user.admin
@@ -204,8 +234,8 @@ class TestUtilSuite:
         assert response1.organization == ex_mng_user.organization
         assert response_status_code1 == constants.HTTPS.UNAUTHORIZED_STATUS_CODE
         with app.app_context():
-            response = rest_api_util.check_if_user_is_authorized(request=req,
-                                                                 requires_admin=True)
+            response = rest_api_util.check_if_user_is_authorized(request=req, requires_admin=True)
+        assert response is not None
         response_data = response[0].data.decode("utf-8")
         response_data_dict = json.loads(response_data)
         response_status_code = response[1]

--- a/simulation-system/libs/csle-system-identification/src/csle_system_identification/emulator.py
+++ b/simulation-system/libs/csle-system-identification/src/csle_system_identification/emulator.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional
+from typing import List, Tuple
 import time
 import os
 import sys


### PR DESCRIPTION
Okej, så jag behövde klura en hel del på denna i början. Anledninen var för att jag behövde göra en request från testfilen som satisfierade jsonify(). När vi använde oss av blueprint och bluebrint.route() i de andra resurserna så kunde ett anrop göras till rest_api_util-funktionerna utan problem för att kolla om man var inloggad eller inte. 

När jag initierade min testfil hursomhelst, så försökte jag göra en dummy-fil först som gjorde en replikering av blueprint och blueprint.route(), följt av en liten funktion som kunde skapa parametern request innan man kallade på check_if_user_is_authoirized, men det gick inte. Jag försökte även lägga den i src/resources utan framgång. Istället så gjorde jag en fejk-parameter request mha en static i test-filen och använde mig av Flask.context() i mina anrop till filen.

Hela anledningen till detta är för att om man kallar på rest_api_util.check_if_user_is_authorized(request=req) rakt av, får man ett error som säger att jsonify kräver rätt context för att ge en response. 

Min lösning funkar med respekt till teskoden och linter, men det som händer med responsen är att man får en nestled tuple, där response (som skickas) i sig blir en tuple som ges av datan plus _ytterligare en status-kod_ som säger att det gick bra att returnera datat. Däremot skickas även den andra status-koden i den yttre tuplen på ett korrekt sätt, och bara man tänker på det i testningen är det inga problem.

Mypy-kommandot verkar inte lira med type-hintingen som finns implementerad i koden, vilket är ett problem. Jag låter det kvarstå då jag inte vill ta bort hints i routes och rest_api_util. Min lösning resulterade också i meddelandet "Value of type "Optional[tuple[Response, int]]" is not indexable", då det frångår från hintingen p.g.a den extra tuplen som fås från context().

Som sagt, jag lyckades inte få till ett replikerad blueprint-anrop utan fick endast 404 not found, och behövde därför skapa parametern request på annat sätt.