### PR TITLE
errors fixed

### DIFF
--- a/simulation-system/libs/csle-common/src/csle_common/dao/training/dqn_policy.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/training/dqn_policy.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Any
 import numpy as np
 import torch
 from stable_baselines3 import DQN
@@ -49,7 +49,7 @@ class DQNPolicy(Policy):
         self.avg_R = avg_R
         self.policy_type = PolicyType.DQN
 
-    def action(self, o: List[float]) -> Union[int, List[int], np.ndarray]:
+    def action(self, o: List[float]) -> Union[int, List[int], np.ndarray[Any, Any]]:
         """
         Multi-threshold stopping policy
 
@@ -59,7 +59,7 @@ class DQNPolicy(Policy):
         a, _ = self.model.predict(np.array(o), deterministic=False)
         return a
 
-    def probability(self, o: List[float], a) -> Union[int, List[int], np.ndarray]:
+    def probability(self, o: List[float], a) -> Union[int, List[int], np.ndarray[Any, Any]]:
         """
         Multi-threshold stopping policy
 
@@ -73,11 +73,11 @@ class DQNPolicy(Policy):
         else:
             return 0
 
-    def to_dict(self) -> Dict[str, Union[float, int, str]]:
+    def to_dict(self) -> Dict[str, Any]:
         """
         :return: a dict representation of the policy
         """
-        d = {}
+        d: Dict[str, Any] = {}
         d["id"] = self.id
         d["simulation_name"] = self.simulation_name
         d["save_path"] = self.save_path
@@ -97,7 +97,7 @@ class DQNPolicy(Policy):
         return d
 
     @staticmethod
-    def from_dict(d: Dict) -> "DQNPolicy":
+    def from_dict(d: Dict[str, Any]) -> "DQNPolicy":
         """
         Converst a dict representation of the object to an instance
 
@@ -111,7 +111,7 @@ class DQNPolicy(Policy):
         obj.id = d["id"]
         return obj
 
-    def stage_policy(self, o: Union[List[Union[int, float]], int, float]) -> List[List[float]]:
+    def stage_policy(self, o: Union[List[int], List[float]]) -> List[List[float]]:
         """
         Gets the stage policy, i.e a |S|x|A| policy
 

--- a/simulation-system/libs/csle-common/src/csle_common/dao/training/mixed_ppo_policy.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/training/mixed_ppo_policy.py
@@ -36,7 +36,7 @@ class MixedPPOPolicy(Policy):
         self.avg_R = avg_R
         self.policy_type = PolicyType.MIXED_PPO_POLICY
 
-    def action(self, o: List[float]) -> Union[int, List[int], np.ndarray]:
+    def action(self, o: List[float]) -> Union[int, List[int], np.ndarray[Any, Any]]:
         """
         Multi-threshold stopping policy
 
@@ -85,7 +85,7 @@ class MixedPPOPolicy(Policy):
         ppo_policies = list(map(lambda x: x.from_dict(), d["ppo_policies"]))
         obj = MixedPPOPolicy(simulation_name=d["simulation_name"],
                              states=list(map(lambda x: State.from_dict(x), d["states"])),
-                             player_type=PlayerType.from_dict(d["player_type"]),
+                             player_type=PlayerType(d["player_type"]),
                              actions=list(map(lambda x: Action.from_dict(x), d["actions"])),
                              experiment_config=ExperimentConfig.from_dict(d["experiment_config"]), avg_R=d["avg_R"])
         obj.ppo_policies = ppo_policies

--- a/simulation-system/libs/csle-common/src/csle_common/dao/training/policy.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/training/policy.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Any
 from abc import abstractmethod
 from csle_common.dao.training.agent_type import AgentType
 from csle_common.dao.training.player_type import PlayerType
@@ -21,7 +21,7 @@ class Policy(JSONSerializable):
         self.player_type = player_type
 
     @abstractmethod
-    def action(self, o: Union[List[Union[int, float]], int, float]) -> Union[int, float]:
+    def action(self, o: Any) -> Any:
         """
         Calculates the next action
 
@@ -40,7 +40,7 @@ class Policy(JSONSerializable):
         pass
 
     @abstractmethod
-    def stage_policy(self, o: Union[List[Union[int, float]], int, float]) -> List[List[float]]:
+    def stage_policy(self, o: Any) -> List[List[float]]:
         """
         Returns a stage policy (see Horak & Bosansky 2019)
 
@@ -61,7 +61,7 @@ class Policy(JSONSerializable):
         pass
 
     @abstractmethod
-    def probability(self, o: Union[List[Union[int, float]], int, float], a: int) -> float:
+    def probability(self, o: Any, a: int) -> float:
         """
         Calculates the probability of a given action for a given observation
 


### PR DESCRIPTION
Okej, dqn_policy och mixed_ppo_policy är fixade så mkt som möjligt. Däremot verkar det som att just return-type-hintingen måste vara densamma för dotter-klasserna som superklassen för att mypy ska vara nöjd. Vi får kika mer på det sen, jag går vidare sålänge.