### PR TITLE
emulation_attacker_observation_state.py

### DIFF
--- a/simulation-system/libs/csle-common/src/csle_common/dao/emulation_observation/attacker/emulation_attacker_observation_state.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/emulation_observation/attacker/emulation_attacker_observation_state.py
@@ -50,8 +50,8 @@ class EmulationAttackerObservationState(JSONSerializable):
         """
         d: Dict[str, Any] = {}
         d["machines"] = list(map(lambda x: x.to_dict(), self.machines))
-        d["catched_flags"] = self.catched_flags
-        d["actions_tried"] = self.actions_tried
+        d["catched_flags"] = list(self.catched_flags)
+        d["actions_tried"] = list(self.actions_tried)
         d["agent_reachable"] = self.agent_reachable
         return d
 


### PR DESCRIPTION
agent_reachable initieras och används som ett set() i koden överlag, men hintas som en lista och behandlas därefter i to_dict, vilket jag misstänker är fel (kan dock vara jag som har fel).

Vissa saker var unreachable, vilket jag ändrade dels med en type-hint, dels med en raise valueerror.