### PR TITLE
nmap_vuln.py

### DIFF
--- a/simulation-system/libs/csle-common/src/csle_common/dao/emulation_action_result/nmap_vuln.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/emulation_action_result/nmap_vuln.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Union
 from csle_common.dao.emulation_observation.common.emulation_vulnerability_observation_state import \
     EmulationVulnerabilityObservationState
 from csle_common.dao.emulation_config.transport_protocol import TransportProtocol
@@ -38,7 +38,9 @@ class NmapVuln(JSONSerializable):
 
         :return: the created VulnerabilityObservationState
         """
-        service = ""
+        service: Optional[str] = ""
+        if self.credentials is None:
+            raise ValueError("self.credentials is None")
         if len(self.credentials) > 0:
             service = self.credentials[0].service
         vuln = EmulationVulnerabilityObservationState(name=self.name, port=self.port, protocol=self.protocol,
@@ -74,7 +76,7 @@ class NmapVuln(JSONSerializable):
 
         :return: a dict representation of the object
         """
-        d = {}
+        d: Dict[str, Any] = {}
         d["name"] = self.name
         d["port"] = self.port
         d["protocol"] = self.protocol

--- a/simulation-system/libs/csle-common/src/csle_common/dao/emulation_observation/common/emulation_vulnerability_observation_state.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/emulation_observation/common/emulation_vulnerability_observation_state.py
@@ -14,7 +14,7 @@ class EmulationVulnerabilityObservationState(JSONSerializable):
 
     def __init__(self, name: str, port: Union[int, None],
                  protocol: TransportProtocol, cvss: float, osvdbid: Optional[int] = None,
-                 description: Optional[str] = None, credentials: Optional[List[Credential]] = None, service: str = ""):
+                 description: Optional[str] = None, credentials: Optional[List[Credential]] = None, service: Optional[str] = ""):
         """
         Initializes the DTO
 


### PR DESCRIPTION
Uppfattade det som rätt att ansätta service: Optional[str] i klassen  EmulationVulnerabilityObservationState då den respekterar detta i __init__. Det löste således många error hos mypy i nmap_vuln.py.