### PR TITLE
reward_function_config.py, transistion_operator_config.py

### DIFF
--- a/simulation-system/libs/csle-common/src/csle_common/dao/simulation_config/reward_function_config.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/simulation_config/reward_function_config.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, List
 
 import numpy as np
+from numpy.typing import NDArray
 
 from csle_base.json_serializable import JSONSerializable
 
@@ -10,7 +11,7 @@ class RewardFunctionConfig(JSONSerializable):
     DTO containing the reward tensor of a simulation
     """
 
-    def __init__(self, reward_tensor: List):
+    def __init__(self, reward_tensor: NDArray[Any]):
         """
         Initalizes the DTO
 
@@ -33,8 +34,8 @@ class RewardFunctionConfig(JSONSerializable):
         """
         :return: a dict representation  of the object
         """
-        d = {}
-        if isinstance(self.reward_tensor, np.ndarray):
+        d: Dict[str, Any] = {}
+        if isinstance(self.reward_tensor, type(NDArray[Any])):
             tensor = self.reward_tensor.tolist()
         else:
             tensor = self.reward_tensor

--- a/simulation-system/libs/csle-common/src/csle_common/dao/simulation_config/transition_operator_config.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/simulation_config/transition_operator_config.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Any
 import numpy as np
+from numpy.typing import NDArray
 from csle_base.json_serializable import JSONSerializable
 
 
@@ -8,7 +9,7 @@ class TransitionOperatorConfig(JSONSerializable):
     DTO representing the transition operator definition of a simulation
     """
 
-    def __init__(self, transition_tensor: List):
+    def __init__(self, transition_tensor: NDArray[Any]):
         """
         Initializes the DTO
 
@@ -33,8 +34,8 @@ class TransitionOperatorConfig(JSONSerializable):
 
         :return: a dict representation of the object
         """
-        d = {}
-        if isinstance(self.transition_tensor, np.ndarray):
+        d: Dict[str, Any] = {}
+        if isinstance(self.transition_tensor, type(NDArray[Any])):
             tensor = self.transition_tensor.tolist()
         else:
             tensor = self.transition_tensor


### PR DESCRIPTION
Ändrade till NDArray, lade till tpye(NDArray[Any]) i isinstance för att bli av med följande error-msg:
"Parameterized generics cannot be used with class or instance checks"

Dock så klagar mypy _alltid_ på att man denna isinsnstance aldrig kommer att bli True, dvs att tensor = self.transition_tensor.tolist() blir unreachable. Det är det enda error som kvartår på dessa