### PR TITLE
alpha_vectors_policy.py

### DIFF
--- a/simulation-system/libs/csle-common/src/csle_common/dao/training/alpha_vectors_policy.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/training/alpha_vectors_policy.py
@@ -81,7 +81,7 @@ class AlphaVectorsPolicy(Policy):
         return a == self.action(o=o)
 
     @staticmethod
-    def from_dict(d: Dict) -> "AlphaVectorsPolicy":
+    def from_dict(d: Dict[str, Any]) -> "AlphaVectorsPolicy":
         """
         Converts a dict representation to an instance
 
@@ -98,11 +98,11 @@ class AlphaVectorsPolicy(Policy):
             dto.id = d["id"]
         return dto
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> Dict[str, Any]:
         """
         :return: A dict representation of the function
         """
-        d = {}
+        d: Dict[str, Any] = {}
         d["agent_type"] = self.agent_type
         d["player_type"] = self.player_type
         d["actions"] = list(map(lambda x: x.to_dict(), self.actions))


### PR DESCRIPTION
Det finns många ställen där vi får ett mypy-error pga att vi har typat en parameter som Union[List[float], in float] och i funktionen antagit att det måste vara en List eftersom vi indexerar. Det går inte riktigt att spåra om det är en bugg eller inte då alla variabler i koden som så småningom tas som en parameter till ett anrop till action (i det här falllet) är typade på samma sätt.

Man skulle kunna göra en if-sats och lösa det på så vis (tror jag gjort det någon gång tidigare) men det känns fel att börja blanda in typing i logiken hos funktionerna (annat än isinstance).