### PR TITLE
policies modified

### DIFF
--- a/simulation-system/libs/csle-common/src/csle_common/dao/training/policy.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/training/policy.py
@@ -1,5 +1,6 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 from abc import abstractmethod
+from numpy.typing import NDArray
 from csle_common.dao.training.agent_type import AgentType
 from csle_common.dao.training.player_type import PlayerType
 from csle_base.json_serializable import JSONSerializable
@@ -21,7 +22,7 @@ class Policy(JSONSerializable):
         self.player_type = player_type
 
     @abstractmethod
-    def action(self, o: Any) -> Any:
+    def action(self, o: Any) -> NDArray[Any]:
         """
         Calculates the next action
 
@@ -61,7 +62,7 @@ class Policy(JSONSerializable):
         pass
 
     @abstractmethod
-    def probability(self, o: Any, a: int) -> float:
+    def probability(self, o: Any, a: int) -> Union[int, float]:
         """
         Calculates the probability of a given action for a given observation
 


### PR DESCRIPTION
Jag stötte på en del problem som jag försökte lösa. 

Jag kommer inte ihåg om det var dessa policies där vi sa att vi skulle skippa None, eftersom det finns i konstruktorn, men anledningen till att jag integrerar ValueErrors i koden m.a.p self.model = None (d.v.s self.model: Optional[PolicyClass]) är för att då blir if-satsen m.a.p None i konstruktorn reachable, utan att Mypy tycks förstå att vi inte behöver tänka på det i funktioner längre ned i koden.

Vad gäller return-type-conflicts mellan superklassen Policy och sub-klasserna, så kvarstod problemet från tidigare, om super-klassens action-funktion returnerar Any så är det det som gäller. Däremot kan det vara så att det är en bugg i DQN- och PPO:s action-funktioner. Predict-attributen som vi hämtar från DQN resp. PPO, och tilldelar till variabeln a, är en Tuple som består av massa element, där det första elementet i Tuplen (som vi vill returnera) är en NDArray. Jag läste dokumentationen och det är så om jag förstått det rätt.

Ett problem som kvarstår är att i PPO så kallar vi på log_prob med en parameter actions som inte ska vara en parameter för den funktionen. Jag har inte hittat någon dokumentation som hänger samman med de klasser som vi kallar på från torch för att komma till log_prob så jag vet inte riktigt vilken parameter som egentligen ska vara där.