### PR TITLE
errors fixed

### DIFF
--- a/simulation-system/libs/csle-common/src/csle_common/dao/emulation_action_result/nmap_port.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/emulation_action_result/nmap_port.py
@@ -64,7 +64,7 @@ class NmapPort(JSONSerializable):
         :param other: the object to compare with
         :return: True if equal otherwise False
         """
-        return (self.port_id == other.port_id)
+        return bool(self.port_id == other.port_id)
 
     def to_obs(self) -> EmulationPortObservationState:
         """

--- a/simulation-system/libs/csle-common/src/csle_common/dao/emulation_action_result/nmap_vuln.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/emulation_action_result/nmap_vuln.py
@@ -67,6 +67,8 @@ class NmapVuln(JSONSerializable):
         """
         :return: a string representation of the object
         """
+        if self.credentials is None:
+            raise ValueError("Credential list is None")
         return f"name:{self.name}, port:{self.port}, protocol:{self.protocol}, cvss:{self.cvss}, " \
                f"service:{self.service}, credentials:{list(map(lambda x: str(x), self.credentials))}"
 
@@ -82,7 +84,8 @@ class NmapVuln(JSONSerializable):
         d["protocol"] = self.protocol
         d["cvss"] = self.cvss
         d["service"] = self.service
-        d["credentials"] = list(map(lambda x: x.to_dict(), self.credentials))
+        d["credentials"] = list(map(lambda x: x.to_dict(), self.credentials)) if \
+            self.credentials is not None else self.credentials
         return d
 
     @staticmethod

--- a/simulation-system/libs/csle-common/src/csle_common/dao/emulation_config/sdn_controller_config.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/emulation_config/sdn_controller_config.py
@@ -57,8 +57,6 @@ class SDNControllerConfig(JSONSerializable):
         :param d: the dict to convert
         :return: the created instance
         """
-        if d is None:
-            return None
         obj = SDNControllerConfig(
             container=NodeContainerConfig.from_dict(d["container"]),
             resources=NodeResourcesConfig.from_dict(d["resources"]),

--- a/simulation-system/libs/csle-common/src/csle_common/dao/emulation_config/services_config.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/emulation_config/services_config.py
@@ -51,7 +51,7 @@ class ServicesConfig(JSONSerializable):
         :param ips: the list of ips
         :return: the list of services
         """
-        services = []
+        services: List[NetworkService] = []
         for service_config in self.services_configs:
             if service_config.ip in ips:
                 services = services + service_config.services

--- a/simulation-system/libs/csle-common/src/csle_common/dao/emulation_observation/attacker/emulation_attacker_observation_state.py
+++ b/simulation-system/libs/csle-common/src/csle_common/dao/emulation_observation/attacker/emulation_attacker_observation_state.py
@@ -12,7 +12,7 @@ class EmulationAttackerObservationState(JSONSerializable):
     Represents the attacker's agent's current belief state of the emulation
     """
 
-    def __init__(self, catched_flags: int, agent_reachable: Set[str]):
+    def __init__(self, catched_flags: int, agent_reachable: Set[str] = set()):
         """
         Initializes the state
 
@@ -188,8 +188,8 @@ class EmulationAttackerObservationState(JSONSerializable):
         :return: a copy of the state
         """
         c = EmulationAttackerObservationState(catched_flags=self.catched_flags,
-                                              agent_reachable=self.agent_reachable.copy())
-        c.actions_tried = self.actions_tried.copy()
+                                              agent_reachable=self.agent_reachable)
+        c.actions_tried = self.actions_tried
         for m in self.machines:
             c.machines.append(m.copy())
         return c

--- a/simulation-system/libs/csle-common/src/csle_common/util/env_dynamics_util.py
+++ b/simulation-system/libs/csle-common/src/csle_common/util/env_dynamics_util.py
@@ -37,10 +37,6 @@ class EnvDynamicsUtil:
         merged_obs_state.catched_flags = max(old_obs_state.catched_flags, new_obs_state.catched_flags)
         merged_obs_state.machines = EnvDynamicsUtil.merge_new_obs_with_old(
             old_obs_state.machines, new_obs_state.machines, emulation_env_config=emulation_env_config, action=None)
-        if old_obs_state.agent_reachable is None:
-            old_obs_state.agent_reachable = set()
-        if new_obs_state.agent_reachable is None:
-            new_obs_state.agent_reachable = set()
         merged_obs_state.agent_reachable = old_obs_state.agent_reachable.union(new_obs_state.agent_reachable)
         return merged_obs_state
 


### PR DESCRIPTION
Det var några variabler som ansattes som tomma set() i konstruktorn (utan att få vara None) hos emulation_attacker_observaton_state, och påstods vara en egen klass med en copy()-funktion nere i EmulationAttackerObservationStates copy()-funktion, så jag ändrade det. Just för att dessa inte heller tillåts vara None, tog jag bort korr. if-satser som kollade det i env_dynamics_util. Möjligen ska det vara tvärtom, att dessa ska vara None, men det kändes som mest rätt att göra såhär.